### PR TITLE
Fix compilation error in form_generator.pl

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -48,3 +48,4 @@ DateTime::Format::SQLite  = 0
 ; You need to install Dist::Zilla::PluginBundle::Git
 [@Git]
 
+[Test::Compile]

--- a/script/form_generator.pl
+++ b/script/form_generator.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-package form_generator.pl;
+package form_generator;
 # ABSTRACT: form generator
 use strict;
 use warnings;


### PR DESCRIPTION
form_generator.pl seems to have an illegal package name (the ".pl"); this remedies that.

It also adds the dzil Test::Compile plugin to dist.ini, to help catch things like this :)
