### PR TITLE
Changed author.t to reproduce a repeatable fields bug

### DIFF
--- a/t/author.t
+++ b/t/author.t
@@ -19,7 +19,7 @@ my @options = $form->field('books.0.genres')->options;
 is(scalar @options, 6, 'got right number of genre options' );
 
 my @formats = $form->field('books.0.format')->options;
-print STDERR "formats ", scalar(@formats), "\n";
+is(scalar @formats, 6, 'got right number of format options');
 
 my $fif = $form->fif;
 

--- a/t/author.t
+++ b/t/author.t
@@ -18,6 +18,9 @@ $form->process( item => $author, params => {});
 my @options = $form->field('books.0.genres')->options;
 is(scalar @options, 6, 'got right number of genre options' );
 
+my @formats = $form->field('books.0.format')->options;
+print STDERR "formats ", scalar(@formats), "\n";
+
 my $fif = $form->fif;
 
 done_testing;

--- a/t/lib/BookDB/Form/Author.pm
+++ b/t/lib/BookDB/Form/Author.pm
@@ -10,13 +10,7 @@ has_field 'first_name' => ( type => 'Text', required => 1 );
 has_field 'country' => ( type => 'Text' );
 has_field 'birthdate' => ( type => 'DateTime' );
 has_field 'books' => ( type => 'Repeatable' );
-has_field 'books.id' => ( type => 'PrimaryKey' );
-has_field 'books.title';
-has_field 'books.publisher';
-has_field 'books.year';
-has_field 'books.genres' => ( type => 'Multiple', label_column => 'name' );
-has_field 'books.format' => ( type => 'Select' );
-
+has_field 'books.contains' => ( type => '+BookDB::Form::Field::Book' );
 
 no HTML::FormHandler::Moose;
 1;

--- a/t/lib/BookDB/Form/Field/Book.pm
+++ b/t/lib/BookDB/Form/Field/Book.pm
@@ -1,0 +1,70 @@
+package BookDB::Form::Field::Book;
+
+use HTML::FormHandler::Moose;
+extends 'HTML::FormHandler::Field::Compound';
+
+has_field 'id' => (
+    type => 'PrimaryKey',
+);
+
+has_field 'title' => (
+    type             => 'Text',
+    required         => 1,
+    required_message => 'A book must have a title.',
+    label            => 'Title',
+);
+has_field 'authors' => (
+    type  => 'Multiple',
+    label => 'Authors',
+);
+
+has_field 'user_updated' => (
+    type => 'Boolean'
+);
+
+# has_many relationship pointing to mapping table
+has_field 'genres' => (
+    type         => 'Multiple',
+    label        => 'Genres',
+    label_column => 'name',
+);
+has_field 'isbn' => (
+    type   => 'Text',
+    label  => 'ISBN',
+    unique => 1,
+);
+has_field 'publisher' => (
+    type  => 'Text',
+    label => 'Publisher',
+);
+has_field 'format' => (
+    type  => 'Select',
+    label => 'Format',
+);
+has_field 'year' => (
+    type        => 'Integer',
+    range_start => '1900',
+    range_end   => '2020',
+    label       => 'Year',
+);
+has_field 'pages' => (
+    type  => 'Integer',
+    label => 'Pages',
+);
+has_field 'comment' => (
+    type  => 'Text',
+);
+
+has_field submit => ( type => 'Submit', value => 'Update' );
+
+sub validate {
+    my $self = shift;
+
+    my $year_field = $self->field('year');
+    $year_field->add_error('Invalid year')
+      if ( ( $year_field->value > 3000 ) || ( $year_field->value < 1600 ) );
+}
+
+__PACKAGE__->meta->make_immutable;
+no HTML::FormHandler::Moose;
+1;


### PR DESCRIPTION
The default options method on Select fields within a repeatable field that uses a .contains Compound field currently dies due to a bug.
