### PR TITLE
column headings weren't being displayed

### DIFF
--- a/t/lib/BookDB/root/book/list.tt
+++ b/t/lib/BookDB/root/book/list.tt
@@ -2,7 +2,7 @@
 <table id="books" cellspacing="0" summary="The list of all books">
 <caption>Table: List of Books</caption>
   <tr>
-    [% FOR column in columns %]
+    [% FOR column IN columns %]
     <th scope="col">[% column %]</th>
     [% END %]
     <th/>


### PR DESCRIPTION
TT commands are case-sensitive - updated FOR .. in to FOR .. IN to fix the column headings
