### PR TITLE
Test and patch for dealing with fields that are unique and inactive

### DIFF
--- a/lib/HTML/FormHandler/TraitFor/Model/DBIC.pm
+++ b/lib/HTML/FormHandler/TraitFor/Model/DBIC.pm
@@ -466,6 +466,7 @@ sub validate_unique
    for my $field ( @$fields )
    {
       next unless $field->unique;
+      next if ( $field->is_inactive || !$field->has_result );
       next if $field->has_errors;
       my $value = $field->value;
       next unless defined $value;

--- a/t/unique.t
+++ b/t/unique.t
@@ -59,4 +59,10 @@ ok( ! $form2->process( $params ), 'duplicate isbn again' );
 
 is( $errors[0], 'Duplicate ISBN number', 'field error message for duplicate');
 
+# Tests for fields that are inactive
+my $item = $schema->resultset('Book')->new({});
+ok ( $form->process( item => $item, params => $params, inactive => ['isbn'] ),
+    'no uniqueness check on inactive fields' );
+$item->delete if $item->in_storage; # Cleanup insert
+
 done_testing;


### PR DESCRIPTION
As mentioned on the mailing list yesterday; this is a small patch that checks a field is active and has a result before checking for errors.

i.e. avoids `$field->has_errors` being delegated to an undef value.
