### PR TITLE
Add a $VERSION to every module, and keep it consistent

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,8 +26,8 @@ repository.type   = git
 
 ; You have to have Dist::Zilla::Plugin::<Name> for these to work
 [PodWeaver]
-[NoTabsTests]
-[EOLTests]
+[Test::NoTabs]
+[Test::EOL]
 [Signature]
 [CheckChangeLog]
 

--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,8 @@ version_regexp = ^([\d._]+)$
 [InstallGuide]
 [MetaJSON]
 
+[PkgVersion]
+
 [MetaResources]
 bugtracker.web    = https://rt.cpan.org/Public/Dist/Display.html?Name=HTML-FormHandler-Model-DBIC
 bugtracker.mailto = bug-HTML-FormHandler-Model-DBIC@rt.cpan.org

--- a/dist.ini
+++ b/dist.ini
@@ -6,10 +6,11 @@ license          = Perl_5
 copyright_holder = Gerda Shank
 copyright_year   = 2013
 
-version = 0.29
-
 [@Git]
 tag_format = %v
+
+[Git::NextVersion]
+version_regexp = ^([\d._]+)$
 
 [@Basic]
 [InstallGuide]

--- a/lib/HTML/FormHandler/Generator/DBIC.pm
+++ b/lib/HTML/FormHandler/Generator/DBIC.pm
@@ -4,7 +4,6 @@ package HTML::FormHandler::Generator::DBIC;
 use Moose;
 use DBIx::Class;
 use Template;
-our $VERSION = '0.04';
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormHandler/Model/DBIC.pm
+++ b/lib/HTML/FormHandler/Model/DBIC.pm
@@ -5,8 +5,6 @@ use Moose;
 extends 'HTML::FormHandler';
 with 'HTML::FormHandler::TraitFor::Model::DBIC';
 
-our $VERSION = '0.29';
-
 =head1 SUMMARY
 
 Empty base class - see L<HTML::FormHandler::TraitFor::Model::DBIC> for

--- a/lib/HTML/FormHandler/TraitFor/Model/DBIC.pm
+++ b/lib/HTML/FormHandler/TraitFor/Model/DBIC.pm
@@ -9,8 +9,6 @@ use DBIx::Class::ResultClass::HashRefInflator;
 use DBIx::Class::ResultSet::RecursiveUpdate;
 use Scalar::Util ('blessed');
 
-our $VERSION = '0.26';
-
 =head1 SYNOPSIS
 
 Subclass your form from HTML::FormHandler::Model::DBIC:

--- a/t/lib/BookDB.pm
+++ b/t/lib/BookDB.pm
@@ -5,8 +5,6 @@ use Catalyst ('-Debug',
               'Static::Simple',
 );
 
-our $VERSION = '0.02';
-
 BookDB->config( name => 'BookDB' );
 
 BookDB->setup;


### PR DESCRIPTION
Some modules lacked a $VERSION, and others had a $VERSION that hadn't been incremented in a long time. This makes it difficult to declare prerequisites in other distributions.

I also changed the dzil config so the version would be automatically calculated from the tag.
