### PR TITLE
Commented out version numbers to have a consistent version

### DIFF
--- a/lib/HTML/FormHandler/Generator/DBIC.pm
+++ b/lib/HTML/FormHandler/Generator/DBIC.pm
@@ -4,7 +4,7 @@ package HTML::FormHandler::Generator::DBIC;
 use Moose;
 use DBIx::Class;
 use Template;
-our $VERSION = '0.04';
+#our $VERSION = '0.04';
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormHandler/Model/DBIC.pm
+++ b/lib/HTML/FormHandler/Model/DBIC.pm
@@ -5,7 +5,7 @@ use Moose;
 extends 'HTML::FormHandler';
 with 'HTML::FormHandler::TraitFor::Model::DBIC';
 
-our $VERSION = '0.29';
+#our $VERSION = '0.29';
 
 =head1 SUMMARY
 

--- a/lib/HTML/FormHandler/TraitFor/Model/DBIC.pm
+++ b/lib/HTML/FormHandler/TraitFor/Model/DBIC.pm
@@ -9,7 +9,7 @@ use DBIx::Class::ResultClass::HashRefInflator;
 use DBIx::Class::ResultSet::RecursiveUpdate;
 use Scalar::Util ('blessed');
 
-our $VERSION = '0.26';
+#our $VERSION = '0.26';
 
 =head1 SYNOPSIS
 

--- a/t/lib/BookDB.pm
+++ b/t/lib/BookDB.pm
@@ -5,7 +5,7 @@ use Catalyst ('-Debug',
               'Static::Simple',
 );
 
-our $VERSION = '0.02';
+#our $VERSION = '0.02';
 
 BookDB->config( name => 'BookDB' );
 


### PR DESCRIPTION
This module had **consistent version** issue at CPANTS, which could be easily solved to improve Kwalitee. That issue happens when you have different version numbers declared at different files. Since you're uzing Dist::Zilla, giving the version number to dist.ini would be enough.

This PR is similar to #13 (which also solves the same problem) but has some differences:
- I did not remove your version numbers from each file, I just commented them out. So if you want to track which file is last updated for which version, you can do it by looking at the beginning of the each file.
- I also did not include a Git::NextVersion to automatically give you a version number.
