### PR TITLE
Declares Minimum Perl Version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,6 +15,8 @@ tag_format = %v
 [InstallGuide]
 [MetaJSON]
 
+[MinimumPerl]
+
 [MetaResources]
 bugtracker.web    = https://rt.cpan.org/Public/Dist/Display.html?Name=HTML-FormHandler-Model-DBIC
 bugtracker.mailto = bug-HTML-FormHandler-Model-DBIC@rt.cpan.org


### PR DESCRIPTION
This module had a warning for **meta yml declares perl version** at CPANTS as an extra metric. This means generated meta.yml file does not have a minimum perl version to check for. This can be easily fixed by adding a simple [MinimumPerl] to dist.ini.
